### PR TITLE
Publication 1.0.3: Fixed Vipps url for Klarna Checkout

### DIFF
--- a/app/code/community/Vipps/Payment/etc/config.xml
+++ b/app/code/community/Vipps/Payment/etc/config.xml
@@ -144,7 +144,7 @@
             <vipps translate="label description" ifconfig="payment/vipps/enabled">
                 <label>Vipps</label>
                 <name>Vipps</name>
-                <redirect_url><![CDATA[{{secure_base_url}}vipps/payment/regular]]></redirect_url>
+                <redirect_url><![CDATA[{{secure_base_url}}vipps/payment_regular]]></redirect_url>
                 <image_url><![CDATA[{{secure_base_url}skin/images/vippspayment/vipps_logo_100x26.png]]></image_url>
                 <description>Checkout using Vipps.</description>
                 <fee>0</fee>


### PR DESCRIPTION
### Release Notes

 - Fixed Vipps initiate payment url that uses for Klarna Checkout